### PR TITLE
Fix scaling issue on Windows

### DIFF
--- a/src/Maui/DrawnUi/Views/DrawnView.cs
+++ b/src/Maui/DrawnUi/Views/DrawnView.cs
@@ -675,7 +675,7 @@ namespace DrawnUi.Views
         {
             NeedCheckParentVisibility = true;
             NeedGlobalRefreshCount++;
-            //RenderingScale = -1;
+            RenderingScale = -1;
             //InvalidateChildren();
             Update();
         }


### PR DESCRIPTION
Previously:
On Windows, normally clicking on buttons in the sandbox app doesn't work at all or ends up selecting the wrong button.

Root cause (per Nick):
i commented this all when optimizing navigating between pages on android to speed up
but looks like sometimes on windows the app manahed to build with 1 scale for you and then scale changes and it keeps previous cache for composite
and this breaks gestures mapping

Fix here:
- Add back setting RenderingScale to -1
