### PR TITLE
1.9.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,10 @@ Supports **iOS**, **MacCatalyst**, **Android**, **Windows** with hardware accele
  
 ---
 
-## 🆕 What's new for 1.9.7.2
+## 🆕 What's new for 1.9.7.3
 
-* Optimized composite cache and added new `SkiaCacheType.ImageCompositeGPU` type.
-* Fix memory leak for the `SkiaCacheType.ImageDoubleBuffered` flow.
-* `SkiaCamera` auto-exposure fix for low light, record video on Android emulator and more. 
-* Various optimizations and fixes.
+* Hotfix for GPU caches to flush instantly after drawing to avoid occasional GPU memory corruption.
+* Update when inivisiblity changes instead of re-painting.
  
 ## 💡 Hint of the Day
 

--- a/nugets/githubupload.bat
+++ b/nugets/githubupload.bat
@@ -13,8 +13,8 @@ REM Define the source directory for the packages
 set "source_dir=C:\Nugets"
 
 REM Define the list of file masks for the packages
-set "mask[1]=DrawnUi.Maui*.1.9.7.2*.nupkg"
-set "mask[2]=AppoMobi.Maui.DrawnUi.1.9.7.2*.*nupkg"
+set "mask[1]=DrawnUi.Maui*.1.9.7.3*.nupkg"
+set "mask[2]=AppoMobi.Maui.DrawnUi.1.9.7.3*.*nupkg"
 set "mask_count=2"
 
 REM Loop through each file mask

--- a/nugets/nugetupload.bat
+++ b/nugets/nugetupload.bat
@@ -13,8 +13,8 @@ REM Define the source directory for the packages
 set "source_dir=C:\Nugets"
 
 REM Define the list of file masks for the packages
-set "mask[1]=DrawnUi.Maui*.1.9.7.2*.nupkg"
-set "mask[2]=AppoMobi.Maui.DrawnUi.1.9.7.2*.*nupkg"
+set "mask[1]=DrawnUi.Maui*.1.9.7.3*.nupkg"
+set "mask[2]=AppoMobi.Maui.DrawnUi.1.9.7.3*.*nupkg"
 set "mask_count=2"
 
 REM Loop through each file mask

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -3,7 +3,7 @@
     <!--For All Post-Build Stuff -->
 
     <PropertyGroup>
-        <Version>1.9.7.2</Version>
+        <Version>1.9.7.3</Version>
         <Authors>Nick Kovalsky aka AppoMobi and contributors</Authors>
         <Copyright>(c) AppoMobi and contributors 2023 - present day</Copyright>
         <PackageProjectUrl>https://github.com/taublast/DrawnUi</PackageProjectUrl>

--- a/src/Maui/DrawnUi/Draw/Base/SkiaControl.Maui.cs
+++ b/src/Maui/DrawnUi/Draw/Base/SkiaControl.Maui.cs
@@ -296,8 +296,6 @@ namespace DrawnUi.Draw
             else if (propertyName.IsEither(nameof(IsVisible)))
             {
                 OnVisibilityChanged(IsVisible);
-
-                Repaint();
             }
 
             #endregion

--- a/src/Maui/DrawnUi/Platforms/Android/DrawnView.Android.cs
+++ b/src/Maui/DrawnUi/Platforms/Android/DrawnView.Android.cs
@@ -166,34 +166,7 @@ namespace DrawnUi.Views
             // The heavy lifting is delegated to the Android-specific method above
             IsHiddenInViewTree = !IsElementVisibleInParentChain(platformView);
 
-            //if (element != null)
-            //{
-
-            //    if (element.Handler != null)
-            //    {
-            //        if (element.Handler.PlatformView is Android.Views.View nativeView)
-            //        {
-            //            if (nativeView.Visibility != Android.Views.ViewStates.Visible)
-            //            {
-            //                IsHiddenInViewTree = true;
-            //                return;
-            //            }
-            //        }
-            //    }
-            //    else
-            //    {
-            //        if (element.GetVisualElementWindow() == null)
-            //        {
-            //            IsHiddenInViewTree = true;
-            //            return;
-            //        }
-            //    }
-
-
-            //}
-
-
-            //IsHiddenInViewTree = false;
+    
         }
 
 #if CHOREOGRAPHER

--- a/src/Maui/Samples/Tutorials/Tutorials.csproj
+++ b/src/Maui/Samples/Tutorials/Tutorials.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup Condition="'$(UseSource)' != 'true'">
-        <PackageReference Include="DrawnUi.Maui" Version="1.9.7.2" />
+        <PackageReference Include="DrawnUi.Maui" Version="1.9.7.3" />
     </ItemGroup>
 
 	<PropertyGroup>

--- a/src/Shared/Draw/Base/SkiaControl.Shared.cs
+++ b/src/Shared/Draw/Base/SkiaControl.Shared.cs
@@ -2404,6 +2404,8 @@ namespace DrawnUi.Draw
             }
 
             SendVisibilityChanged();
+
+            Update();
         }
 
         void StopPostAnimators()

--- a/src/Shared/Internals/Models/CachedObject.cs
+++ b/src/Shared/Internals/Models/CachedObject.cs
@@ -67,6 +67,12 @@ public class CachedObject : ISkiaDisposable
 
                 canvas.DrawImage(Image, x, y, paint);
                 LastDrawnAt = new(x, y, Bounds.Width + x, Bounds.Height + y);
+
+                if (Surface != null && Surface.Context != null)
+                {
+                    //GPU
+                    //canvas.Flush();
+                }
             }
         }
         catch (Exception e)
@@ -106,8 +112,14 @@ public class CachedObject : ISkiaDisposable
             {
                 canvas.DrawImage(Image, x, y, paint);
                 LastDrawnAt = new(x, y, Bounds.Width + x, Bounds.Height + y);
-            }
 
+
+                if (Surface != null && Surface.Context != null)
+                {
+                    //GPU
+                    //canvas.Flush();
+                }
+            }
         }
         catch (Exception e)
         {


### PR DESCRIPTION
* Hotfix for GPU caches to flush instantly after drawing to avoid occasional GPU memory corruption.
* Update when inivisiblity changes instead of re-painting.