### PR TITLE
Fix gesture hit-testing for transformed controls in virtualized/cached scrolls

### DIFF
--- a/src/Shared/Draw/Base/SkiaControl.Shared.cs
+++ b/src/Shared/Draw/Base/SkiaControl.Shared.cs
@@ -1724,6 +1724,7 @@ namespace DrawnUi.Draw
             if (child.Control != null && !child.Control.IsDisposing && !child.Control.IsDisposed &&
                 !child.Control.InputTransparent && child.Control.CanDraw)
             {
+                child.Control.EnsureRenderTransformMatrixForGestures();
                 if (child.Control.HasTransform && child.Control.RenderTransformMatrix.TryInvert(out SKMatrix inverse))
                 {
                     // Transform point into child's local space
@@ -2202,6 +2203,10 @@ namespace DrawnUi.Draw
 
             var consumedDefault = BlockGesturesBelow ? this as ISkiaGestureListener : null;
 
+            // Make sure our transform matrix is current before using it to map the incoming coordinate
+            // (node-attached / cached controls can leave it stale at Identity — see the helper).
+            EnsureRenderTransformMatrixForGestures();
+
             if (HasTransform)
             {
                 // Transform the mapped location using the inverse transformation matrix
@@ -2385,7 +2390,23 @@ namespace DrawnUi.Draw
                         if (CheckChildrenGesturesLocked(args.Type))
                             return consumedDefault;
 
-                        var point = TranslateInputOffsetToPixels(args.Event.Location, apply.ChildOffset);
+                        // For TRANSFORMED controls, hit-test registered gesture-listener children with the
+                        // entry-mapped location (apply.MappedLocation, already in this control's local space
+                        // incl. the transform), consistent with the rendering-tree branch above and the entry
+                        // inverse-map — the raw args.Event.Location ignored the transform so children of a
+                        // transformed control (e.g. an inverted/flipped chat scroll) were never hit. For the
+                        // common non-transformed case, keep the original path exactly (no behavioural change).
+                        SKPoint point;
+                        if (HasTransform)
+                        {
+                            var listenersOffset = TranslateInputCoords(apply.ChildOffset);
+                            point = new SKPoint(apply.MappedLocation.X + listenersOffset.X,
+                                apply.MappedLocation.Y + listenersOffset.Y);
+                        }
+                        else
+                        {
+                            point = TranslateInputOffsetToPixels(args.Event.Location, apply.ChildOffset);
+                        }
 
                         ISkiaGestureListener breakForChild = null;
 
@@ -4502,6 +4523,27 @@ namespace DrawnUi.Draw
             // Apply to canvas (concat with canvas total matrix)
             matrix = matrix.PostConcat(ctx.Canvas.TotalMatrix);
             ctx.Canvas.SetMatrix(matrix);
+        }
+
+        /// <summary>
+        /// Ensures <see cref="RenderTransformMatrix"/> reflects the current transform so gesture hit-testing
+        /// (the inverse-map in ProcessGestures and IsGestureForChild) accounts for it. Node-attached / cached
+        /// controls apply their transform to the canvas (or bake it into a cache) without storing it here, so
+        /// it can be left at Identity even though the control is visibly scaled/rotated/flipped — which makes
+        /// pointer events miss the control's children. Recompute on demand from the current DrawingRect; this
+        /// is cheap (a single matrix build) and only runs for transformed controls whose matrix is stale.
+        /// </summary>
+        public void EnsureRenderTransformMatrixForGestures()
+        {
+            // Always recompute for transformed controls from the CURRENT DrawingRect: besides the
+            // node-attached/cached case (matrix left at Identity), a virtualized control's DrawingRect
+            // moves as it scrolls, so a matrix built at render time carries a stale transform pivot and
+            // the inverse-map lands in the wrong place. Recomputing here keeps the pivot current. Cheap
+            // (one matrix build) and only for transformed controls.
+            if (HasTransform && DrawingRect != SKRect.Empty)
+            {
+                CreateTransformationMatrix(null, DrawingRect);
+            }
         }
 
         public virtual SKPoint TranslateInputDirectOffsetToPoints(PointF location, SKPoint childOffsetDirect)

--- a/src/Shared/Draw/Scroll/SkiaScroll.Planes.cs
+++ b/src/Shared/Draw/Scroll/SkiaScroll.Planes.cs
@@ -891,10 +891,25 @@ namespace DrawnUi.Draw
             // Calculate the plane's current rendered position
             var planeOffsetY = currentScroll + plane.OffsetY;
 
-            // Keep gesture coordinates as-is, but adjust child HitRects to current plane position
+            // Adjust child HitRects to current plane position (below). Also map the gesture into this
+            // scroll's local (pre-transform) space so both hit-testing and the coordinates forwarded to
+            // children account for any transform on the scroll itself (e.g. ScaleY=-1 / RotationZ for an
+            // inverted chat list). The base ProcessGestures applies this at entry, but the virtualized
+            // planes path overrides ProcessGestures and never reaches it, so a transformed virtualized
+            // scroll would otherwise hit-test raw coords against un-transformed child rects (hitting the
+            // mirror-image child) and forward raw coords (dead taps inside transformed cells).
+            EnsureRenderTransformMatrixForGestures();
+
             var gesturePoint = new SKPoint(
                 args.Event.Location.X + thisOffset.X,
                 args.Event.Location.Y + thisOffset.Y);
+
+            var childMappedLocation = apply.MappedLocation;
+            if (HasTransform && RenderTransformMatrix.TryInvert(out SKMatrix gestureInverse))
+            {
+                gesturePoint = gestureInverse.MapPoint(gesturePoint);
+                childMappedLocation = gestureInverse.MapPoint(apply.MappedLocation);
+            }
 
 
             // Process gestures using plane's render tree in reverse Z-order
@@ -963,10 +978,10 @@ namespace DrawnUi.Draw
                         {
                             var childOffset = TranslateInputCoords(apply.ChildOffsetDirect, false);
 
-                            // Forward gesture to child with proper coordinate transformation
+                            // Forward gesture to child with the scroll-local mapped coordinate (see above).
                             var consumed = listener.OnSkiaGestureEvent(args,
                                 new GestureEventProcessingInfo(
-                                    apply.MappedLocation,
+                                    childMappedLocation,
                                     thisOffset,
                                     childOffset,
                                     apply.AlreadyConsumed));
@@ -981,7 +996,7 @@ namespace DrawnUi.Draw
                             {
                                 var attachedConsumed = effect.OnSkiaGestureEvent(args,
                                     new GestureEventProcessingInfo(
-                                        apply.MappedLocation,
+                                        childMappedLocation,
                                         thisOffset,
                                         childOffset,
                                         apply.AlreadyConsumed));

--- a/src/Shared/Draw/Text/SkiaLabel.cs
+++ b/src/Shared/Draw/Text/SkiaLabel.cs
@@ -3753,9 +3753,12 @@ namespace DrawnUi.Draw
             {
                 //apply transfroms
                 var thisOffset = TranslateInputCoords(apply.ChildOffset, true);
-                //apply touch coords
-                var x = args.Event.Location.X + thisOffset.X;
-                var y = args.Event.Location.Y + thisOffset.Y;
+                //apply touch coords. Use the entry-mapped MappedLocation (which the gesture pipeline has
+                //already transformed into this control's space through any parent transforms) rather than
+                //the raw args.Event.Location, so span (link) hit-testing works when the label is inside a
+                //scaled/rotated/flipped/virtualized parent — e.g. an inverted chat list.
+                var x = apply.MappedLocation.X + thisOffset.X;
+                var y = apply.MappedLocation.Y + thisOffset.Y;
 
                 foreach (var span in Spans.ToList())
                 {


### PR DESCRIPTION
# PR: Fix gesture hit-testing for transformed controls in virtualized/cached scrolls

Fixes #302.

## Problem
A control with a transform (`ScaleX/ScaleY`, `Rotation*`, skew, flip) renders correctly but pointer
events never reach its children — the transform is applied to rendering but ignored by gesture
hit-testing. This breaks the standard inverted-list pattern (a `ScaleY="-1"` `SkiaScroll` with
counter-flipped cells for a newest-at-bottom chat list) inside virtualization: cells render upright,
but taps on links/buttons inside a cell do nothing. See the linked issue for the full root-cause.

## Fix
Gesture hit-testing only — no rendering changes:

1. **`SkiaControl.EnsureRenderTransformMatrixForGestures()`** (new): recomputes `RenderTransformMatrix`
   from the current `DrawingRect` for transformed controls. Called before the inverse-map in
   `ProcessGestures` and in `IsGestureForChild`. Fixes the stale/Identity matrix on node-attached/cached
   controls and the stale pivot on virtualized controls (whose `DrawingRect` moves as they scroll).
2. **`SkiaScroll.ProcessGesturesForPlane`**: map the gesture point and the forwarded `MappedLocation`
   by the scroll's transform (the virtualized planes path overrides `ProcessGestures` and never reaches
   the base entry inverse-map).
3. **`SkiaControl.ProcessGestures` (registered-listener branch)**: hit-test transformed controls with
   the entry-mapped `MappedLocation` (consistent with the rendering-tree branch); the non-transformed
   path is kept exactly as before.
4. **`SkiaLabel.ProcessGestures`**: span (link) hit-testing uses the entry-mapped `MappedLocation`
   instead of the raw `args.Event.Location`.

Three files: `SkiaControl.Shared.cs`, `SkiaScroll.Planes.cs`, `SkiaLabel.cs`.

## No regression for non-transformed UI
Changes 1–3 are gated on `HasTransform`; change 4 is identical to the previous behaviour when nothing
in the ancestry is transformed, because `MappedLocation == args.Event.Location` in that case (the root
sets `MappedLocation = touchLocation` and the entry inverse-map is a no-op without a transform). So a
normal, non-transformed list takes byte-identical code paths.

## Testing
- **Android (net10):** verified that tapping a URL link inside a cell of an inverted
  (`ScaleY="-1"`) virtualized `SkiaScroll` now fires (opens the browser); without the change the tap is
  detected on the cell but never reaches the label's link span.
- **Non-transformed regression check:** the same list with the transforms removed still routes taps
  correctly (the gated paths fall through to the original behaviour).
- The change is platform-agnostic C#; I could not run the iOS/MacCatalyst matrix on a Windows-only host.

## Notes / for discussion
- `EnsureRenderTransformMatrixForGestures()` recomputes the matrix per gesture event for transformed
  controls (a single cheap matrix build). If preferred, this could be made dirty-tracked / cached and
  invalidated on transform or layout change — happy to adjust.
- The registered-listener branch was previously inconsistent with the rendering-tree branch (raw vs
  mapped coordinates); this aligns them for transformed controls while leaving the common path intact.
