### PR TITLE
Fix hardcoded path breaking CI nuget pack

### DIFF
--- a/src/OpenTk/DrawnUi/DrawnUi.OpenTk.csproj
+++ b/src/OpenTk/DrawnUi/DrawnUi.OpenTk.csproj
@@ -52,7 +52,7 @@
   <ItemGroup>
     <Compile Remove="$(MSBuildThisFileDirectory)..\..\Shared\Features\Pdf\Pdf.cs" />
     <Compile Remove="$(MSBuildThisFileDirectory)..\..\Shared\Draw\Base\VisualTreeHandler.cs" />
-    <Compile Remove="C:\Dev\Cases\GitHub\DrawnUi\src\OpenTk\DrawnUi\..\..\Net\DrawnUi\Super.Net.cs" />
+    <Compile Remove="$(MSBuildThisFileDirectory)..\..\Net\DrawnUi\Super.Net.cs" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
One-line fix: Compile Remove for Super.Net.cs used absolute local path, no-op on CI runner, causing duplicate Super member errors in DrawnUi.OpenTk pack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)